### PR TITLE
Add dealloc to AMPopTip.

### DIFF
--- a/AMPopTip/AMPopTip.m
+++ b/AMPopTip/AMPopTip.m
@@ -70,6 +70,11 @@
     return self;
 }
 
+- (void)dealloc{
+  [_removeGesture removeTarget:self action:@selector(removeGestureHandler)];
+  _removeGesture = nil;
+}
+
 - (void)layoutSubviews
 {
     [self setup];


### PR DESCRIPTION
If you remove AMPopTips from the screen using any other method than the `removeGesture`, it was possible to crash your app by having the gesture recognizer call out to a deallocated target. This protects against that.
