### PR TITLE
Add ability for a swipe to dismiss pop tip.

### DIFF
--- a/Source/AMPopTip.h
+++ b/Source/AMPopTip.h
@@ -341,6 +341,19 @@ typedef NS_ENUM(NSInteger, AMPopTipActionAnimation) {
  */
 @property (nonatomic, assign) BOOL shouldDismissOnTapOutside;
 
+/** Dismiss on swipe outside
+*
+* A boolean value that determines whether to dismiss when swiping outside the popover.
+*/
+@property (nonatomic, assign) BOOL shouldDismissOnSwipeOutside;
+
+/** Direction to dismiss on swipe outside
+*
+* A direction that determines what swipe direction to dismiss when swiping outside the popover.
+* The default direction is UISwipeGestureRecognizerDirectionRight if this is not set.
+*/
+@property (nonatomic, assign) UISwipeGestureRecognizerDirection swipeRemoveGestureDirection;
+
 /** Tap handler
  *
  * A block that will be fired when the user taps the popover.

--- a/Source/AMPopTip.m
+++ b/Source/AMPopTip.m
@@ -18,7 +18,8 @@
 @property (nonatomic, strong) NSAttributedString *attributedText;
 @property (nonatomic, strong) NSMutableParagraphStyle *paragraphStyle;
 @property (nonatomic, strong) UITapGestureRecognizer *gestureRecognizer;
-@property (nonatomic, strong) UITapGestureRecognizer *removeGesture;
+@property (nonatomic, strong) UITapGestureRecognizer *tapRemoveGesture;
+@property (nonatomic, strong) UISwipeGestureRecognizer *swipeRemoveGesture;
 @property (nonatomic, strong) NSTimer *dismissTimer;
 @property (nonatomic, weak, readwrite) UIView *containerView;
 @property (nonatomic, assign, readwrite) AMPopTipDirection direction;
@@ -85,7 +86,8 @@
     _actionPulseOffset = kDefaultPulseOffset;
     _actionAnimationIn = kDefaultBounceAnimationIn;
     _actionAnimationOut = kDefaultBounceAnimationOut;
-    _removeGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(removeGestureHandler)];
+    _tapRemoveGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapRemoveGestureHandler)];
+    _swipeRemoveGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(swipeRemoveGestureHandler)];
 }
 
 - (void)layoutSubviews {
@@ -227,8 +229,14 @@
     }
 }
 
-- (void)removeGestureHandler {
+- (void)tapRemoveGestureHandler {
     if (self.shouldDismissOnTapOutside) {
+        [self hide];
+    }
+}
+
+- (void)swipeRemoveGestureHandler {
+    if (self.shouldDismissOnSwipeOutside) {
         [self hide];
     }
 }
@@ -269,7 +277,8 @@
     __weak AMPopTip *weakSelf = self;
     [self performEntranceAnimation:^{
         weakSelf.isVisible = YES;
-        [self.containerView addGestureRecognizer:self.removeGesture];
+        [self.containerView addGestureRecognizer:self.tapRemoveGesture];
+        [self.containerView addGestureRecognizer:self.swipeRemoveGesture];
         if (self.appearHandler) {
             self.appearHandler();
         }
@@ -335,7 +344,8 @@
 - (void)hide {
     [self.dismissTimer invalidate];
     self.dismissTimer = nil;
-    [self.containerView removeGestureRecognizer:self.removeGesture];
+    [self.containerView removeGestureRecognizer:self.tapRemoveGesture];
+    [self.containerView removeGestureRecognizer:self.swipeRemoveGesture];
     if (self.superview) {
         self.transform = CGAffineTransformIdentity;
         [UIView animateWithDuration:self.animationOut delay:self.delayOut options:(UIViewAnimationOptionCurveEaseInOut | UIViewAnimationOptionBeginFromCurrentState) animations:^{
@@ -369,12 +379,25 @@
 
 - (void)setShouldDismissOnTapOutside:(BOOL)shouldDismissOnTapOutside {
     _shouldDismissOnTapOutside = shouldDismissOnTapOutside;
-    _removeGesture.enabled = shouldDismissOnTapOutside;
+    _tapRemoveGesture.enabled = shouldDismissOnTapOutside;
+}
+
+- (void)setShouldDismissOnSwipeOutside:(BOOL)shouldDismissOnSwipeOutside {
+    _shouldDismissOnSwipeOutside = shouldDismissOnSwipeOutside;
+    _swipeRemoveGesture.enabled = shouldDismissOnSwipeOutside;
+}
+
+- (void)setSwipeRemoveGestureDirection:(UISwipeGestureRecognizerDirection)swipeRemoveGestureDirection {
+    _swipeRemoveGestureDirection = swipeRemoveGestureDirection;
+    _swipeRemoveGesture.direction = swipeRemoveGestureDirection;
 }
 
 - (void)dealloc {
-    [_removeGesture removeTarget:self action:@selector(removeGestureHandler)];
-    _removeGesture = nil;
+    [_tapRemoveGesture removeTarget:self action:@selector(tapRemoveGestureHandler)];
+    _tapRemoveGesture = nil;
+
+    [_swipeRemoveGesture removeTarget:self action:@selector(swipeRemoveGestureHandler)];
+    _swipeRemoveGesture = nil;
 }
 
 @end


### PR DESCRIPTION
DESCRIPTION
---
There is currently an option to dismiss the PopTip when a tap is performed outside of the PopTip. There should also be the option to dismiss the PopTip when a swipe is performed outside of the PopTip. Some PopTips may read "Swipe left to do *X*", in which case a user performing a swipe should be able to dismiss that PopTip.

PROPOSED CHANGES
---
Add a `UISwipeGestureRecognizer` that will dismiss the PopTip when a swipe is performed. Due to adding an additional `removeGesture` I renamed the existing to `tapRemoveGesture` and added `swipeRemoveGesture`. The swipe direction is [defaulted](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UISwipeGestureRecognizer_Class/index.html#//apple_ref/occ/instp/UISwipeGestureRecognizer/direction) to `UISwipeGestureRecognizerDirectionRight`. The direction can also be set if you want to use a different swipe direction.

This was kept out of the `commonInit` to avoid accidentally enabling this feature for users.


TESTING SUGGESTIONS
---
* Point your podfile (or however you pull this in) at this branch/commit, or pull in this change. 
* Where you initialize your PopTip, add `self.shouldDismissOnSwipeOutside = YES;`
  * Perform a right swipe with a PopTip displayed, and it should dismiss it. 
* After that line you just added, add `self.swipeRemoveGestureDirection = UISwipeGestureRecognizerDirectionLeft;`. 
  * Perform a left swipe, and the PopTip should be dismissed.
* Without `shouldDismissOnSwipeOutside` set to `YES`, swipes should not dismiss the PopTip, regardless if the direction is set.

**Please Review:** @andreamazz 