### PR TITLE
This fix corrects an issue where text with CR/LF will not be displayed correctly

### DIFF
--- a/Source/AMPopTip.m
+++ b/Source/AMPopTip.m
@@ -108,14 +108,17 @@
     }
 
     if (self.text != nil) {
-        self.textBounds = [self.text boundingRectWithSize:(CGSize){self.maxWidth, DBL_MAX }
-                                                  options:NSStringDrawingUsesLineFragmentOrigin
-                                               attributes:@{NSFontAttributeName: self.font}
-                                                  context:nil];
+        UITextView *textView = [[UITextView alloc] init];
+        textView.font = self.font;
+        textView.text = self.text;
+        CGSize size = [textView sizeThatFits:CGSizeMake(self.maxWidth, DBL_MAX)];
+        self.textBounds = CGRectMake(0, 0, size.width, size.height);
     } else if (self.attributedText != nil) {
-        self.textBounds = [self.attributedText boundingRectWithSize:(CGSize){self.maxWidth, DBL_MAX }
-                                                            options:NSStringDrawingUsesLineFragmentOrigin
-                                                            context:nil];
+        UITextView *textView = [[UITextView alloc] init];
+        textView.font = self.font;
+        textView.attributedText = self.attributedText;
+        CGSize size = [textView sizeThatFits:CGSizeMake(self.maxWidth, DBL_MAX)];
+        self.textBounds = CGRectMake(0, 0, size.width, size.height);
     } else if (self.customView != nil) {
         self.textBounds = self.customView.frame;
     }


### PR DESCRIPTION
In my application I have noticed that text continuing CR/LF do not have their size computed correctly using the oldboundingRectWithSize approach.

The approach of creating a textView and letting it calculate the size is returning better values for multi line text.