### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/PopTipDemo/Pods/Expecta/README.md
+++ b/PopTipDemo/Pods/Expecta/README.md
@@ -1,4 +1,4 @@
-#Expecta
+# Expecta
 
 [![Build Status](http://img.shields.io/travis/specta/expecta/master.svg?style=flat)](https://travis-ci.org/specta/expecta)
 [![Pod Version](http://img.shields.io/cocoapods/v/Expecta.svg?style=flat)](http://cocoadocs.org/docsets/Expecta/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
