### PR TITLE
Fix arrow position .none rectContained() check for left and top clipping

### DIFF
--- a/Source/PopTip.swift
+++ b/Source/PopTip.swift
@@ -314,10 +314,10 @@ open class PopTip: UIView {
     var finalRect = rect
     
     // The `.none` positioning implies a rect with the origin in the middle of the poptip
-    if (rect.origin.x - rect.width / 2) < containerView.frame.origin.x {
+    if (rect.origin.x) < containerView.frame.origin.x {
       finalRect.origin.x = edgeMargin
     }
-    if (rect.origin.y - rect.height / 2) < containerView.frame.origin.y {
+    if (rect.origin.y) < containerView.frame.origin.y {
       finalRect.origin.y = edgeMargin
     }
     if (rect.origin.x + rect.width) > (containerView.frame.origin.x + containerView.frame.width) {


### PR DESCRIPTION
Adding correct check of left and top clipping.
Further details posted at #133 and andreamazz/AMPopTip@b9ceeb5

The check for the centered container expanding over the bounds of the containerView was not correctly accounting for the rect's origin.

Popover with arrow direction .none is shown centered but rect.origin is set to the top left corner by previous calculations: https://github.com/andreamazz/AMPopTip/blob/d2155f1269f23d7541a91d3697415f0d5fadf2b1/Source/PopTip.swift#L396

Therefore the check should not perform subtraction of `width/2` or `height/2`.
The bottom and right side clipping already perform calculations with the correct origin:
https://github.com/andreamazz/AMPopTip/blob/d2155f1269f23d7541a91d3697415f0d5fadf2b1/Source/PopTip.swift#L323
https://github.com/andreamazz/AMPopTip/blob/d2155f1269f23d7541a91d3697415f0d5fadf2b1/Source/PopTip.swift#L326

