### PR TITLE
Fix compilation for static linking

### DIFF
--- a/Source/PopTip+Draw.swift
+++ b/Source/PopTip+Draw.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Andrea Mazzini. All rights reserved.
 //
 
+import UIKit
+
 fileprivate func degreesToRadians(degrees: CGFloat) -> CGFloat {
   return (CGFloat.pi * degrees) / 180
 }

--- a/Source/PopTip+Transitions.swift
+++ b/Source/PopTip+Transitions.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Andrea Mazzini. All rights reserved.
 //
 
+import UIKit
+
 public extension PopTip {
 
   /// Triggers the chosen entrance animation


### PR DESCRIPTION
Compilation fails when framework linked as static: see podspec attribute: `s.static_framework = true`