### PR TITLE
When the originating frame is tapped, call the tapHandler.

### DIFF
--- a/Source/PopTip.swift
+++ b/Source/PopTip.swift
@@ -168,6 +168,9 @@ open class PopTip: UIView {
   @objc open dynamic var shouldDismissOnTap = true
   /// A boolean value that determines whether to dismiss when tapping outside the poptip.
   @objc open dynamic var shouldDismissOnTapOutside = true
+  /// A boolean value that determines whether to consider the originating frame as part of the poptip,
+  /// i.e wether to call the `tapHandler` or the `tapOutsideHandler` when the tap occurs in the `from` frame.
+  @objc open dynamic var shouldConsiderOriginatingFrameAsPopTip = false
   /// A boolean value that determines whether to dismiss when swiping outside the poptip.
   @objc open dynamic var shouldDismissOnSwipeOutside = false
   /// A boolean value that determines if the action animation should start automatically when the poptip is shown
@@ -710,7 +713,12 @@ open class PopTip: UIView {
     if shouldDismissOnTapOutside {
       hide()
     }
-    tapOutsideHandler?(self)
+
+    if shouldConsiderOriginatingFrameAsPopTip && from.contains(gesture.location(in: containerView)) {
+      tapHandler?(self)
+    } else {
+      tapOutsideHandler?(self)
+    }
   }
   
   @objc fileprivate func handleSwipeOutside(_ gesture: UITapGestureRecognizer) {


### PR DESCRIPTION
I've implemented a solution for issue [#173](https://github.com/andreamazz/AMPopTip/issues/173).

I've added a property called `shouldConsiderOriginatingFrameAsPopTip` which indicates whether the originating frame is considered as being part of the PopTip. When the user's taps this frame, instead of triggering the tapOutsideHandler, the tapHandler is called.

This is achieved by checking whether a tap in the `containerView` originated from within the `from` frame. This check is performed in the `handleTapOutside` method.

---

I'm not a big fan of how this is implemented. Here are two other solutions that I have thought of, but they require a small rewrite.

**Solution 1**
We can rename the `handleTapOutside` method to `handleRemoveTap`. This has the benefit of matching the naming used for the different gesture recognizers. Depending on where the tap originated from, we can call a `handleTapOutside` method. The implementation would look like this:

```swift
@objc fileprivate func handleRemoveTap(_ gesture: UITapGestureRecognizer) {
  let isLocatedInside = from.contains(gesture.location(in: containerView))
  if shouldConsiderOriginatingFrameAsPopTip && isLocatedInside {
    handleTap(gesture)
  } else {
    handleTapOutside()
  }
}

fileprivate func handleTapOutside() {
  if shouldDismissOnTapOutside {
    hide()
  }
  tapOutsideHandler?(self)
}
```

**Solution 2**
The `show` method could accept a `UIView` instead of a `CGRect`, which would unable us to add a third gesture recognizer. This would trigger a block:

```swift
tapInsideFrameHandler: ((PopTip) -> Void)?
```

Unfortunately, this would be a breaking change to the existing API.