### PR TITLE
'public' modifier is redundant for instance method declared in a public extension

### DIFF
--- a/Source/PopTip+Transitions.swift
+++ b/Source/PopTip+Transitions.swift
@@ -13,7 +13,7 @@ public extension PopTip {
   /// Triggers the chosen entrance animation
   ///
   /// - Parameter completion: the completion handler
-  public func performEntranceAnimation(completion: @escaping () -> Void) {
+  func performEntranceAnimation(completion: @escaping () -> Void) {
     switch entranceAnimation {
     case .scale:
       entranceScale(completion: completion)
@@ -39,7 +39,7 @@ public extension PopTip {
   /// Triggers the chosen exit animation
   ///
   /// - Parameter completion: the completion handler
-  public func performExitAnimation(completion: @escaping () -> Void) {
+  func performExitAnimation(completion: @escaping () -> Void) {
     switch exitAnimation {
     case .scale:
       exitScale(completion: completion)


### PR DESCRIPTION
Xcode warnings show up when you integrate AMPopTip.

<img width="491" alt="screen shot 2019-02-22 at 10 33 17" src="https://user-images.githubusercontent.com/839992/53215863-7d2e8480-368d-11e9-9e6a-a8ebf0f17ac8.png">
