### PR TITLE
improving tap remove gesture reocgnizer access level

### DIFF
--- a/Source/PopTip.swift
+++ b/Source/PopTip.swift
@@ -237,7 +237,8 @@ open class PopTip: UIView {
   open private(set) var tapGestureRecognizer: UITapGestureRecognizer?
   fileprivate var attributedText: NSAttributedString?
   fileprivate var paragraphStyle = NSMutableParagraphStyle()
-  fileprivate var tapRemoveGestureRecognizer: UITapGestureRecognizer?
+  /// The tap remove gesture recognizer. Read-only.
+  open private(set) var tapRemoveGestureRecognizer: UITapGestureRecognizer?
   fileprivate var swipeGestureRecognizer: UISwipeGestureRecognizer?
   fileprivate var dismissTimer: Timer?
   fileprivate var textBounds = CGRect.zero
@@ -512,6 +513,7 @@ open class PopTip: UIView {
     }
     if shouldDismissOnTapOutside && tapRemoveGestureRecognizer == nil {
       tapRemoveGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PopTip.handleTapOutside(_:)))
+      tapRemoveGestureRecognizer?.cancelsTouchesInView = false
     }
     if shouldDismissOnSwipeOutside && swipeGestureRecognizer == nil {
       swipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(PopTip.handleSwipeOutside(_:)))


### PR DESCRIPTION
When working with table view/collection view, the pop tips' `tapRemoveGestureRecognizer `interferes with touch events being delivered to table view/collection view because the touch event gets canceled by the `tapRemoveGestureRecognizer`, which prevents a smooth experience for users. Especially when we add a pop tip for a cell, they need to first dismiss the pop tip then tap again to take their required action.
I would suggest adding `tapRemoveGestureRecognizer.cancelsTouchesInView = false` ,  to solve this issue.
I also suggest making **tapRemoveGestureRecognizer** public, so the developers can have enough freedom to edit its behavior according to their needs. 