### PR TITLE
Work around canImport(Combine) being broken in Xcode 13

### DIFF
--- a/Source/PopTip.swift
+++ b/Source/PopTip.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-#if canImport(SwiftUI) && canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import SwiftUI
 #endif
 
@@ -644,7 +644,7 @@ open class PopTip: UIView {
     show(duration: duration)
   }
 
-#if canImport(SwiftUI) && canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
   /// Shows an animated poptip in a given view, from a given rectangle. The property `isVisible` will be `true` as soon as the poptip is added to the given view.
   ///
   /// - Parameters:


### PR DESCRIPTION
Applying the same fix as used by the Realm project 

> Xcode 13 beta 3 added a swiftinterface file for armv7 Combine which makes canImport(Combine) return true, but the swiftinterface file doesn't actually compile (and no armv7 devices can run OS versions with Combine). Work around this by replacing the canImport(Combine) checks with a define we manually set when building for armv7.

https://github.com/realm/realm-cocoa/pull/7401