### PR TITLE
[S] Add cutout and gradient background

### DIFF
--- a/Demo/PopTip Demo/ViewController.swift
+++ b/Demo/PopTip Demo/ViewController.swift
@@ -39,6 +39,7 @@ class ViewController: UIViewController {
     popTip.shouldDismissOnTap = true
     popTip.shouldDismissOnTapOutside = true
     popTip.shouldDismissOnSwipeOutside = true
+    popTip.shouldConsiderCutoutTapSeparately = true
     popTip.edgeMargin = 5
     popTip.offset = 2
     popTip.bubbleOffset = 0
@@ -64,6 +65,10 @@ class ViewController: UIViewController {
     popTip.tapOutsideHandler = { _ in
       print("tap outside")
     }
+    
+    popTip.tapCutoutHandler = { _ in
+      print("tap cutout")
+    }
 
     popTip.swipeOutsideHandler = { _ in
       print("swipe outside")
@@ -78,6 +83,7 @@ class ViewController: UIViewController {
   }
   
   var showSwiftUIView = false
+  var showMaskAndCutout = false
 
   @IBAction func action(sender: UIButton) {
     guard let button = ButtonType(rawValue: sender.tag) else { return }
@@ -85,6 +91,16 @@ class ViewController: UIViewController {
     timer?.invalidate()
     
     popTip.arrowRadius = 0
+    
+    switch button {
+    case .topRight:
+      showMaskAndCutout.toggle()
+      popTip.shouldShowMask = showMaskAndCutout
+      popTip.shouldCutoutMask = showMaskAndCutout
+    default:
+      popTip.shouldShowMask = false
+      popTip.shouldCutoutMask = false
+    }
     
     switch button {
     case .topLeft:

--- a/Demo/PopTip Demo/ViewController.swift
+++ b/Demo/PopTip Demo/ViewController.swift
@@ -102,6 +102,23 @@ class ViewController: UIViewController {
       popTip.shouldCutoutMask = false
     }
     
+    popTip.bubbleLayerGenerator = { path in
+      guard button == .bottomLeft else { return nil } // Only use bubbleLayer when button is bottomLeft
+      
+      let gradient = CAGradientLayer()
+      gradient.frame = path.bounds
+      gradient.colors = [UIColor.black.withAlphaComponent(0.4).cgColor, UIColor.black.withAlphaComponent(0.3)]
+      gradient.locations = [0, 1]
+      gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+      gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        
+      let shapeMask = CAShapeLayer()
+      shapeMask.path = path.cgPath
+      gradient.mask = shapeMask
+      
+      return gradient
+    }
+    
     switch button {
     case .topLeft:
       popTip.bubbleColor = UIColor(red: 0.95, green: 0.65, blue: 0.21, alpha: 1)
@@ -154,6 +171,7 @@ class ViewController: UIViewController {
       let underline: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 13), NSAttributedString.Key.foregroundColor: UIColor.white, NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue]
       let attributedText = NSMutableAttributedString(string: "I'm presenting a string ", attributes: attributes)
       attributedText.append(NSAttributedString(string: "with attributes!", attributes: underline))
+      attributedText.append(NSAttributedString(string: " And custom background!", attributes: attributes))
       popTip.show(attributedText: attributedText, direction: .up, maxWidth: 200, in: view, from: sender.frame)
       
     case .bottomRight:

--- a/Source/PopTip+Transitions.swift
+++ b/Source/PopTip+Transitions.swift
@@ -22,14 +22,14 @@ public extension PopTip {
     case .fadeIn:
       entranceFadeIn(completion: completion)
     case .custom:
-      if let backgroundMask = backgroundMask {
-        containerView?.addSubview(backgroundMask)
+      if shouldShowMask {
+        addBackgroundMask(to: containerView)
       }
       containerView?.addSubview(self)
       entranceAnimationHandler?(completion)
     case .none:
-      if let backgroundMask = backgroundMask {
-        containerView?.addSubview(backgroundMask)
+      if shouldShowMask {
+        addBackgroundMask(to: containerView)
       }
       containerView?.addSubview(self)
       completion()
@@ -65,8 +65,8 @@ public extension PopTip {
       transform = transform.translatedBy(x: (containerView?.frame.width ?? 0) - from.origin.x, y: 0)
     case .auto, .autoHorizontal, .autoVertical: break // The decision will be made at this point
     }
-    if let backgroundMask = backgroundMask {
-      containerView?.addSubview(backgroundMask)
+    if shouldShowMask {
+      addBackgroundMask(to: containerView)
     }
     containerView?.addSubview(self)
 
@@ -80,8 +80,8 @@ public extension PopTip {
 
   private func entranceScale(completion: @escaping () -> Void) {
     transform = CGAffineTransform(scaleX: 0, y: 0)
-    if let backgroundMask = backgroundMask {
-      containerView?.addSubview(backgroundMask)
+    if shouldShowMask {
+      addBackgroundMask(to: containerView)
     }
     containerView?.addSubview(self)
 
@@ -94,8 +94,8 @@ public extension PopTip {
   }
 
   private func entranceFadeIn(completion: @escaping () -> Void) {
-    if let backgroundMask = backgroundMask {
-      containerView?.addSubview(backgroundMask)
+    if shouldShowMask {
+      addBackgroundMask(to: containerView)
     }
     containerView?.addSubview(self)
 
@@ -128,5 +128,34 @@ public extension PopTip {
     }) { (_) in
       completion()
     }
+  }
+    
+  private func addBackgroundMask(to targetView: UIView?) {
+
+    guard let backgroundMask = backgroundMask, let targetView = targetView else { return }
+      
+    targetView.addSubview(backgroundMask)
+
+    guard shouldCutoutMask else {
+      backgroundMask.backgroundColor = maskColor
+      return
+    }
+
+    let cutoutView = UIView(frame: backgroundMask.bounds)
+    let cutoutShapeMaskLayer = CAShapeLayer()
+    let cutoutPath = cutoutPathGenerator(from)
+    let path = UIBezierPath(rect: backgroundMask.bounds)
+
+    path.append(cutoutPath)
+
+    cutoutShapeMaskLayer.path = path.cgPath
+    cutoutShapeMaskLayer.fillRule = .evenOdd
+
+    cutoutView.layer.mask = cutoutShapeMaskLayer
+    cutoutView.clipsToBounds = true
+    cutoutView.backgroundColor = maskColor
+    cutoutView.isUserInteractionEnabled = false
+
+    backgroundMask.addSubview(cutoutView)
   }
 }


### PR DESCRIPTION
# Change description
This PR should provide some additional functionality to the library. This includes:
- the ability to have a cutout in the mask to "highlight" the content the PopTip is pointing to with the option to call a separate closure when this area is tapped, as well as allowing the consumer to specify a closure that can control the path generated for the cutout. The example has been modified to demo this via the `topRight` button as an alternating appearing feature (implements #194)
- the ability to provide `CALayer` via a closure that can allow the consumer to do whatever they want with the bubble background. The example has been modified to include a gradient background for the `bottomLeft` button (implements #201)

The `README.md` has been edited to:
- include some missing customisation options already present in the library
- include new information around the functionality added

# Testing
Testing the functionality should be entirely possible via the demo project already included within the project as I just edited the `topRight` and `bottomLeft` button actions to modify the `PopTip` conditionally. However, (hopefully enough) instructions are available in the updated `README.md`

# Closing notes
If there are any issues, or questions around these changes, please let me know! If all is good with this @andreamazz, it'd be great to be able to have it merged and the version bumped as appropriate! 😄 

_As an aside, when using the SwiftUI `func show`, if the `SwiftUI` view contents is too wide, it expands the bubble to be off the screen, thus losing/"clipping" content. For a more basic SwiftUI view that is a simple `VStack` containing two child `Text` elements with long text, the text will not wrap as desired either._