### PR TITLE
[S] Allow SwiftUI content view to size up until maximum width

### DIFF
--- a/Demo/PopTip Demo/SwiftUIView.swift
+++ b/Demo/PopTip Demo/SwiftUIView.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 
 @available(iOS 13.0, *)
-struct SwiftUIView: View {
+struct SwiftUIOneView: View {
   
   var items = [Item(string: "First"),
                Item(string: "Second"),
@@ -44,9 +44,37 @@ class Item: Identifiable {
 }
 
 @available(iOS 13.0, *)
-struct SwiftUIView_Previews: PreviewProvider {
+struct SwiftUIOneView_Previews: PreviewProvider {
   static var previews: some View {
-    SwiftUIView()
+    SwiftUIOneView()
+      .previewLayout(.sizeThatFits)
   }
 }
+
+@available(iOS 13.0, *)
+struct SwiftUITwoView: View {
+  
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text("This is a title")
+        Text("This is an AMPopTip which utilises a SwiftUI view as its content")
+      }
+      Spacer(minLength: 0)
+      Image(systemName: "bubble.left")
+        .resizable()
+        .scaledToFit()
+        .frame(width: 12, height: 12)
+    }
+  }
+}
+
+@available(iOS 13.0, *)
+struct SwiftUITwoView_Previews: PreviewProvider {
+  static var previews: some View {
+    SwiftUITwoView()
+      .previewLayout(.sizeThatFits)
+  }
+}
+
 #endif

--- a/Demo/PopTip Demo/ViewController.swift
+++ b/Demo/PopTip Demo/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 import AMPopTip
 
 class ViewController: UIViewController {
@@ -82,6 +83,7 @@ class ViewController: UIViewController {
     autolayoutView?.frame.size = CGSize(width: 180, height: 100)
   }
   
+  var swiftUIView = false
   var showSwiftUIView = false
   var showMaskAndCutout = false
 
@@ -140,7 +142,12 @@ class ViewController: UIViewController {
       }
       else if #available(iOS 13.0.0, *) {
         #if canImport(SwiftUI) && canImport(Combine)
-        popTip.show(rootView: SwiftUIView(), direction: .down, in: view, from: sender.frame, parent: self)
+        if swiftUIView {
+          popTip.show(rootView: SwiftUIOneView(), direction: .down, in: view, from: sender.frame, parent: self)
+        } else {
+          popTip.show(rootView: SwiftUITwoView(), direction: .down, in: view, from: sender.frame, parent: self)
+        }
+        self.swiftUIView.toggle()
         #endif
       }
       popTip.entranceAnimationHandler = { [weak self] completion in

--- a/Source/PopTip.swift
+++ b/Source/PopTip.swift
@@ -689,7 +689,9 @@ open class PopTip: UIView {
     containerView = view
     let controller = UIHostingController(rootView: rootView)
     controller.view.backgroundColor = .clear
-    controller.view.frame.size = controller.view.intrinsicContentSize
+    let maxContentWidth = UIScreen.main.bounds.width - (self.edgeMargin * 2) - self.edgeInsets.horizontal - (self.padding * 2)
+    let sizeThatFits = controller.view.sizeThatFits(CGSize(width: maxContentWidth, height: CGFloat.greatestFiniteMagnitude))
+    controller.view.frame.size = CGSize(width: min(sizeThatFits.width, maxContentWidth), height: sizeThatFits.height)
     maxWidth = controller.view.frame.size.width
     self.customView?.removeFromSuperview()
     self.customView = controller.view


### PR DESCRIPTION
## Change Description
This PR should allow a SwiftUI view that is being used within the PopTip to resize a little better. Previously if the content of a SwiftUI content view was too wide it would just run of the screen, or if given a fixed width (using the `.frame(width: 200)` view modifier on the SwiftUI itself) then text would truncate instead of wrapping onto new lines. Hopefully this change should **improve** this behaviour by modifying the frame calculation for the UIHostingViewController view within the `show` method. Essentially a maximum width is calculated which is the width of the device minus padding/margin/etc. so that the full thing is still visible, and then the height is derived using the `UIView` method `sizeThatFits`. This is not a perfect solution, but is an improvement in my opinion - thoughts?

This could be improved to work better with different directions, and applied to the other variants of PopTip.

This partially addresses the issue I mentioned at the end of my last PR https://github.com/andreamazz/AMPopTip/pull/239.

## Testing
Testing this functionality should be possible by playing around with the SwiftUI views within `SwiftUIView.swift`.  A second view has been added which utilises different behaviours, and it automatically toggles when tapping the `topLeft` button (so it will now cycle between custom view and a SwiftUI view where the SwiftUI view also alternates each time).

## Closing notes
If there are any issues, or questions around these changes, please let me know! If all is good with this @andreamazz, it'd be great to be able to have it merged and the version bumped as appropriate - it does change the existing behaviour for those that use it, so may be worth doing a decent bump! 😄