### PR TITLE
Fix unexpected behavior when dismissing a poptip during the entrance animation.

### DIFF
--- a/Source/PopTip.swift
+++ b/Source/PopTip.swift
@@ -245,6 +245,8 @@ open class PopTip: UIView {
   open private(set) var direction = PopTipDirection.none
   /// Holds the readonly BOOL with the poptip animation state.
   open private(set) var isAnimating: Bool = false
+  /// Holds the readonly BOOL with the state of the poptip exit animation.
+  open private(set) var isPerformingExitAnimation: Bool = false
   /// The view that dims the background (including the button that triggered PopTip.
   /// The mask by appears with fade in effect only.
   open private(set) var backgroundMask: UIView?
@@ -763,12 +765,14 @@ open class PopTip: UIView {
       self.layer.removeAllAnimations()
       self.transform = .identity
       self.isAnimating = false
+      self.isPerformingExitAnimation = false
       self.dismissHandler?(self)
     }
 
     if isApplicationInBackground ?? false {
       completion()
     } else {
+      isPerformingExitAnimation = true
       performExitAnimation(completion: completion)
     }
   }
@@ -817,6 +821,10 @@ open class PopTip: UIView {
 
     setNeedsLayout()
     performEntranceAnimation {
+      guard !self.isPerformingExitAnimation && self.isVisible else {
+        return
+      }
+        
       self.customView?.layoutIfNeeded()
 
       if let tapRemoveGesture = self.tapToRemoveGestureRecognizer {


### PR DESCRIPTION
I was encountering an issue where I was using `hide(forced: true)` during the poptip entrance animation, and it would cause unexpected animations (my poptip would briefly fill the whole screen), and would cause other elements of my UI to stop responding to taps. 

This seemed to be due to the code that is run in the completion handler of `performEntranceAnimation` in `show(duration:)`, which was mixing in unexpected ways with the exit animation.

This change introduces a new piece of state tracking whether the exit animation is occurring, and uses that to block the post-entrance-animation code from running in this case, which seems to resolve the issues I was encountering.

I have not exhaustively tested this behavior, but it is working properly in my own app. If there are tests I should run or other scenarios you'd like me to check, let me know.